### PR TITLE
Fixing an include issue

### DIFF
--- a/SwiftyAcknowledgements/UIFontDescriptorExtensions.swift
+++ b/SwiftyAcknowledgements/UIFontDescriptorExtensions.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UIKit
 
 internal extension UIFontDescriptor {
     


### PR DESCRIPTION
Under some circumstances (especially when using SPM), this can fail to compile without including UIKit.